### PR TITLE
Add in location to form

### DIFF
--- a/src/frontend/PetSpotR/Data/PetModel.cs
+++ b/src/frontend/PetSpotR/Data/PetModel.cs
@@ -11,7 +11,7 @@ namespace PetSpotR.Models
         public string ID { get; set; }
         public string State { get; set; }
         public List<string> Images { get; set; }
-
+        public string Location { get; set; }
 
         // Constructor
         public PetModel()
@@ -23,6 +23,7 @@ namespace PetSpotR.Models
             ID = Guid.NewGuid().ToString();
             State = "new";
             Images = new();
+            Location = "";
         }
 
         public async Task SavePetStateAsync(DaprClient daprClient, string storeName)

--- a/src/frontend/PetSpotR/Pages/LostPet.razor
+++ b/src/frontend/PetSpotR/Pages/LostPet.razor
@@ -24,8 +24,36 @@
                 <InputSelect id="type" @bind-Value="petModel.Type">
                     <option>Dog</option>
                     <option>Cat</option>
+                    <option>Bird</option>
+                    <option>Other</option>
                 </InputSelect>
             </div>
+        </div>
+        <div class="form-group row justify-content-center">
+            <label for="petLocation" class="col-2 col-form-label">Pet Location</label>
+            <div class="col-4">
+                <InputSelect id="petLocation" @bind-Value="petModel.Location">
+                    <!-- add suburbs to the dropdown and give the options for suburbs located in Melbourne, Australia -->
+                    <option>Melbourne</option>
+                    <option>Geelong</option>
+                    <option>Bendigo</option>
+                    <option>Ballarat</option>
+                    <option>Shepparton</option>
+                    <option>Melton</option>
+                    <option>Mildura</option>
+                    <option>Warrnambool</option>   
+                    <option>Sunbury</option>
+                    <option>Pakenham</option>
+                    <option>Wodonga</option>
+                    <option>Traralgon</option>
+                    <option>Hoppers Crossing</option>
+                    <option>New York</option>
+                    <option>Los Angeles</option>
+                    <option>Chicago</option>
+                    <!-- Add more options as needed -->
+                </InputSelect>
+            </div>
+        </div>
         </div>
         <div class="form-group row justify-content-center">
             <label for="petBreed" class="col-2 col-form-label">Pet Breed</label>


### PR DESCRIPTION
This pull request primarily focuses on the enhancement of the `PetModel` class and the `LostPet.razor` page in the `PetSpotR` frontend. The most significant changes involve adding a `Location` property to the `PetModel` class and extending the `LostPet.razor` page to include more pet types and a new pet location selector.

Addition to `PetModel` class:

* [`src/frontend/PetSpotR/Data/PetModel.cs`](diffhunk://#diff-b207c3aa67f5ecda63a4bcf68fe118605c1d30ad620b712719f11c83f9a8a323R14): Added a new property `Location` to the `PetModel` class. This property is initialized to an empty string in the `PetModel` constructor. [[1]](diffhunk://#diff-b207c3aa67f5ecda63a4bcf68fe118605c1d30ad620b712719f11c83f9a8a323R14) [[2]](diffhunk://#diff-b207c3aa67f5ecda63a4bcf68fe118605c1d30ad620b712719f11c83f9a8a323R26)

Updates to `LostPet.razor` page:

* [`src/frontend/PetSpotR/Pages/LostPet.razor`](diffhunk://#diff-bd2f227ec5eb0910f4f70aea4a81c434282d1da806c7550bfd95f50604cd9fc5R27-R57): Added 'Bird' and 'Other' options to the pet type dropdown. Also, introduced a new dropdown for pet location with various options including cities from Australia and the United States.
