### PR TITLE
Fix CI not always running correctly

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -45,6 +45,11 @@ jobs:
       run: |
         cd tests/playwright
         npx playwright install --with-deps
+    - name: Start app
+      if: ${{ env.TEST_URL == 'http://localhost:5114/' }}
+      run: |
+        scripts/dev &
+        npx wait-on tcp:5114
     - name: Run Playwright tests
       run: |
         cd tests/playwright

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__
+PetSpotR.generated.sln
+petimages

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -105,12 +105,4 @@ const config: PlaywrightTestConfig = {
   // outputDir: 'test-results/',
 };
 
-if (test_url?.includes('localhost')) {
-  /* Run your local dev server before starting the tests */
-  config.webServer = {
-    command: '../../scripts/dev',
-    url: 'http://localhost:5114/'
-  };
-}
-
 export default config;


### PR DESCRIPTION
As playwright used to manage the running of the server, we had one browser close another's running instance. Let's do this slightly different.